### PR TITLE
docs(es): remove use of reactivity transform

### DIFF
--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -716,9 +716,5 @@ export default defineConfigWithTheme<ThemeConfig>({
     json: {
       stringify: true
     }
-  },
-
-  vue: {
-    reactivityTransform: true
   }
 })

--- a/.vitepress/theme/components/Banner.vue
+++ b/.vitepress/theme/components/Banner.vue
@@ -5,13 +5,13 @@
  * 2. uncomment and update BANNER_ID in ../../inlined-scripts/restorePreferences.ts
  * 3. update --vt-banner-height if necessary
  */
-
-let open = $ref(true)
+import { ref } from 'vue'
+let open = ref(true)
 /**
  * Call this if the banner is dismissible
  */
 function dismiss() {
-  open = false
+  open.value = false
   document.documentElement.classList.add('banner-dismissed')
   localStorage.setItem(`vue-docs-banner-${__VUE_BANNER_ID__}`, 'true')
 }

--- a/.vitepress/theme/components/PreferenceSwitch.vue
+++ b/.vitepress/theme/components/PreferenceSwitch.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { VTSwitch, VTIconChevronDown } from '@vue/theme'
 import { useRoute } from 'vitepress'
-import { inject, Ref } from 'vue'
+import { ref, computed, inject, Ref } from 'vue'
 import {
   preferCompositionKey,
   preferComposition,
@@ -10,15 +10,15 @@ import {
 } from './preferences'
 
 const route = useRoute()
-const show = $computed(() =>
+const show = computed(() =>
   /^\/(guide|tutorial|examples)\//.test(route.path)
 )
-const showSFC = $computed(() => !/^\/guide/.test(route.path))
+const showSFC = computed(() => !/^\/guide/.test(route.path))
 
-let isOpen = $ref(true)
+let isOpen = ref(true)
 
 const toggleOpen = () => {
-  isOpen = !isOpen
+  isOpen.value = !isOpen
 }
 
 const removeOutline = (e: Event) => {

--- a/.vitepress/theme/components/SponsorsGroup.vue
+++ b/.vitepress/theme/components/SponsorsGroup.vue
@@ -1,29 +1,34 @@
 <script setup lang="ts">
-import { onMounted, onUnmounted } from 'vue'
+import { ref, onMounted, onUnmounted } from 'vue'
 import { SponsorData, data, base, load } from './sponsors'
 
 type Placement = 'aside' | 'page' | 'landing'
 
-const { tier, placement = 'aside' } = defineProps<{
-  tier: keyof SponsorData
-  placement?: Placement
-}>()
+const props = withDefaults(
+  defineProps<{
+    tier: keyof SponsorData
+    placement?: Placement
+  }>(),
+  {
+    placement: 'aside'
+  }
+)
 
-let container = $ref<HTMLElement>()
-let visible = $ref(false)
+const container = ref<HTMLElement>()
+const visible = ref(false)
 
 onMounted(async () => {
   // only render when entering view
   const observer = new IntersectionObserver(
     (entries) => {
       if (entries[0].isIntersecting) {
-        visible = true
+        visible.value = true
         observer.disconnect()
       }
     },
     { rootMargin: '0px 0px 300px 0px' }
   )
-  observer.observe(container!)
+  observer.observe(container.value!)
   onUnmounted(() => observer.disconnect())
 
   // load data
@@ -37,7 +42,7 @@ const eventMap: Record<Placement, string> = {
   page: 'ZXLO3IUT'
 }
 function track(interest?: boolean) {
-  fathom.trackGoal(interest ? `Y2BVYNT2` : eventMap[placement], 0)
+  fathom.trackGoal(interest ? `Y2BVYNT2` : eventMap[props.placement], 0)
 }
 </script>
 

--- a/.vitepress/theme/components/VueJobs.vue
+++ b/.vitepress/theme/components/VueJobs.vue
@@ -1,8 +1,9 @@
 <script lang="ts">
+import { ref } from 'vue'
 // shared data across instances so we load only once
 const base = `https://app.vuejobs.com/feed/vuejs/docs?format=json`
 
-let items = $ref<Jobs[]>([])
+const items = ref<Jobs[]>([])
 
 type Jobs = {
   organization: Organization
@@ -21,19 +22,17 @@ type Organization = {
 <script setup lang="ts">
 import { onMounted, computed } from 'vue'
 
-let vuejobs = $ref<HTMLElement>()
-
 const openings = computed(() =>
-  items.sort(() => 0.5 - Math.random()).slice(0, 2)
+  items.value.sort(() => 0.5 - Math.random()).slice(0, 2)
 )
 
 onMounted(async () => {
-  if (!items.length) items = (await (await fetch(`${base}`)).json()).data
+  if (!items.value.length) items.value = (await (await fetch(`${base}`)).json()).data
 })
 </script>
 
 <template>
-  <div class="vuejobs-wrapper" ref="vuejobs">
+  <div class="vuejobs-wrapper">
     <div class="vj-container">
       <a
         class="vj-item"

--- a/.vitepress/theme/components/VueMasteryModal.vue
+++ b/.vitepress/theme/components/VueMasteryModal.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
-import { watch } from 'vue'
+import { ref, watch } from 'vue'
 
 const VIDEO_SOURCE = 'https://player.vimeo.com/video/647441538?autoplay=1'
-let showWhyVue: boolean = $ref(false)
+const showWhyVue = ref(false)
 
 watch(
   () => showWhyVue,

--- a/env.d.ts
+++ b/env.d.ts
@@ -1,5 +1,4 @@
 /// <reference types="vitepress/client" />
-/// <reference types="vue/macros-global" />
 
 declare module '@vue/theme/config' {
   import { UserConfig } from 'vitepress'

--- a/src/about/releases.md
+++ b/src/about/releases.md
@@ -3,13 +3,13 @@ outline: deep
 ---
 
 <script setup>
-import { onMounted } from 'vue'
+import { ref, onMounted } from 'vue'
 
-let version = $ref()
+const version = ref()
 
 onMounted(async () => {
   const res = await fetch('https://api.github.com/repos/vuejs/core/releases?per_page=1')
-  version = (await res.json())[0].name
+  version.value = (await res.json())[0].name
 })
 </script>
 

--- a/src/guide/built-ins/keep-alive-demos/CompA.vue
+++ b/src/guide/built-ins/keep-alive-demos/CompA.vue
@@ -1,5 +1,6 @@
 <script setup>
-let count = $ref(0)
+import { ref } from 'vue'
+let count = ref(0)
 </script>
 
 <template>

--- a/src/guide/built-ins/keep-alive-demos/CompB.vue
+++ b/src/guide/built-ins/keep-alive-demos/CompB.vue
@@ -1,5 +1,6 @@
 <script setup>
-let msg = $ref('')
+import { ref } from 'vue'
+const msg = ref('')
 </script>
 
 <template>

--- a/src/guide/built-ins/keep-alive-demos/SwitchComponent.vue
+++ b/src/guide/built-ins/keep-alive-demos/SwitchComponent.vue
@@ -1,10 +1,11 @@
 <script setup>
+import { shallowRef } from 'vue'
 import CompA from './CompA.vue'
 import CompB from './CompB.vue'
 
-let current = $shallowRef(CompA)
+const current = shallowRef(CompA)
 
-const { useKeepAlive } = defineProps({ useKeepAlive: Boolean })
+defineProps({ useKeepAlive: Boolean })
 </script>
 
 <template>

--- a/src/guide/built-ins/teleport.md
+++ b/src/guide/built-ins/teleport.md
@@ -116,7 +116,8 @@ El objetivo `to` de `<Teleport>` espera una cadena de selección CSS o un nodo D
 Puedes hacer clic en el botón de abajo e inspeccionar la etiqueta `<body>` a través de las herramientas de desarrollo de tu navegador:
 
 <script setup>
-let open = $ref(false)
+import { ref } from 'vue'
+let open = ref(false)
 </script>
 
 <div class="demo">

--- a/src/guide/built-ins/transition-demos/Basic.vue
+++ b/src/guide/built-ins/transition-demos/Basic.vue
@@ -1,5 +1,6 @@
 <script setup>
-let show = $ref(true)
+import { ref } from 'vue'
+let show = ref(true)
 </script>
 
 <template>

--- a/src/guide/built-ins/transition-demos/BetweenComponents.vue
+++ b/src/guide/built-ins/transition-demos/BetweenComponents.vue
@@ -1,10 +1,10 @@
 <script setup>
-import { h } from 'vue'
+import { h, ref } from 'vue'
 
 const CompA = () => h('div', 'Component A')
 const CompB = () => h('div', 'Component B')
 
-let activeComponent = $ref(CompA)
+const activeComponent = ref(CompA)
 </script>
 
 <template>

--- a/src/guide/built-ins/transition-demos/BetweenElements.vue
+++ b/src/guide/built-ins/transition-demos/BetweenElements.vue
@@ -1,7 +1,9 @@
 <script setup>
-const { mode } = defineProps(['mode'])
+import { ref } from 'vue'
 
-let docState = $ref('saved')
+defineProps(['mode'])
+
+const docState = ref('saved')
 </script>
 
 <template>

--- a/src/guide/built-ins/transition-demos/CssAnimation.vue
+++ b/src/guide/built-ins/transition-demos/CssAnimation.vue
@@ -1,5 +1,6 @@
 <script setup>
-let show = $ref(true)
+import { ref } from 'vue'
+const show = ref(true)
 </script>
 
 <template>

--- a/src/guide/built-ins/transition-demos/JsHooks.vue
+++ b/src/guide/built-ins/transition-demos/JsHooks.vue
@@ -1,7 +1,8 @@
 <script setup>
+import { ref } from 'vue'
 import gsap from 'gsap'
 
-let show = $ref(true)
+const show = ref(true)
 
 function onBeforeEnter(el) {
   gsap.set(el, {

--- a/src/guide/built-ins/transition-demos/ListMove.vue
+++ b/src/guide/built-ins/transition-demos/ListMove.vue
@@ -1,17 +1,18 @@
 <script setup>
-let items = $ref([1, 2, 3, 4, 5])
+import { ref } from 'vue'
+const items = ref([1, 2, 3, 4, 5])
 let nextNum = items.length + 1
 
 function add() {
-  items.splice(randomIndex(), 0, nextNum++)
+  items.value.splice(randomIndex(), 0, nextNum++)
 }
 
 function remove() {
-  items.splice(randomIndex(), 1)
+  items.value.splice(randomIndex(), 1)
 }
 
 function randomIndex() {
-  return Math.floor(Math.random() * items.length)
+  return Math.floor(Math.random() * items.value.length)
 }
 
 function shuffle(array) {

--- a/src/guide/built-ins/transition-demos/ListStagger.vue
+++ b/src/guide/built-ins/transition-demos/ListStagger.vue
@@ -1,4 +1,5 @@
 <script setup>
+import { ref, computed } from 'vue'
 import gsap from 'gsap'
 
 const list = [
@@ -9,9 +10,9 @@ const list = [
   { msg: 'Kung Fury' }
 ]
 
-let query = $ref('')
+const query = ref('')
 
-const computedList = $computed(() => {
+const computedList = computed(() => {
   return list.filter((item) => item.msg.toLowerCase().includes(query))
 })
 

--- a/src/guide/built-ins/transition-demos/NestedTransitions.vue
+++ b/src/guide/built-ins/transition-demos/NestedTransitions.vue
@@ -1,5 +1,6 @@
 <script setup>
-let show = $ref(true)
+import { ref } from 'vue'
+const show = ref(true)
 </script>
 
 <template>

--- a/src/guide/built-ins/transition-demos/SlideFade.vue
+++ b/src/guide/built-ins/transition-demos/SlideFade.vue
@@ -1,5 +1,6 @@
 <script setup>
-let show = $ref(true)
+import { ref } from 'vue'
+const show = ref(true)
 </script>
 
 <template>

--- a/src/guide/essentials/reactivity-fundamentals.md
+++ b/src/guide/essentials/reactivity-fundamentals.md
@@ -573,28 +573,3 @@ export default {
 ```
 
 </div>
-
-<div class="composition-api">
-
-## Transformación de la Reactividad <sup class="vt-badge experimental" /> \*\* {#reactivity-transform}
-
-Tener que utilizar `.value` con las refs es un inconveniente impuesto por las restricciones del lenguaje JavaScript. Sin embargo, con las transformaciones en tiempo de compilación podemos mejorar la ergonomía añadiendo automáticamente `.value` en los lugares adecuados. Vue proporciona una transformación en tiempo de compilación que nos permite escribir el ejemplo anterior del "counter" de esta manera:
-
-```vue
-<script setup>
-let count = $ref(0)
-
-function increment() {
-  // no hay necesidad de .value
-  count++
-}
-</script>
-
-<template>
-  <button @click="increment">{{ count }}</button>
-</template>
-```
-
-Puedes obtener más información sobre [Transformación de la Reactividad](/guide/extras/reactivity-transform.html) en su sección dedicada. Ten en cuenta que actualmente es todavía experimental y puede cambiar antes de ser finalizado.
-
-</div>

--- a/src/guide/extras/demos/Colors.vue
+++ b/src/guide/extras/demos/Colors.vue
@@ -1,7 +1,10 @@
 <script setup>
-let x = $ref(0)
+import { ref } from 'vue'
+
+const x = ref(0)
+
 function onMousemove(e) {
-  x = e.clientX
+  x.value = e.clientX
 }
 </script>
 

--- a/src/guide/extras/demos/DisabledButton.vue
+++ b/src/guide/extras/demos/DisabledButton.vue
@@ -1,10 +1,11 @@
 <script setup>
-let notActivated = $ref(false)
+import { ref } from 'vue'
+const notActivated = ref(false)
 
 function warnNotActivated() {
-  notActivated = true
+  notActivated.value = true
   setTimeout(() => {
-    notActivated = false
+    notActivated.value = false
   }, 1500)
 }
 </script>

--- a/src/guide/extras/demos/ElasticHeader.vue
+++ b/src/guide/extras/demos/ElasticHeader.vue
@@ -1,18 +1,20 @@
 <script setup>
+import { ref, computed } from 'vue'
 import dynamics from 'dynamics.js'
 
 const headerHeight = 120
 
 let isDragging = false
 const start = { x: 0, y: 0 }
-let c = $ref({ x: headerHeight, y: headerHeight })
+const x = ref(headerHeight)
+const y = ref(headerHeight)
 
-const headerPath = $computed(() => {
-  return `M0,0 L320,0 320,${headerHeight}Q${c.x},${c.y} 0,${headerHeight}`
+const headerPath = computed(() => {
+  return `M0,0 L320,0 320,${headerHeight}Q${x.value},${y.value} 0,${headerHeight}`
 })
 
-const contentPosition = $computed(() => {
-  const dy = c.y - headerHeight
+const contentPosition = computed(() => {
+  const dy = y.value - headerHeight
   const dampen = dy > 0 ? 2 : 4
   return {
     transform: `translate(0,${dy / dampen}px)`
@@ -29,10 +31,10 @@ function startDrag(e) {
 function onDrag(e) {
   e = e.changedTouches ? e.changedTouches[0] : e
   if (isDragging) {
-    c.x = headerHeight + (e.pageX - start.x)
+    x.value = headerHeight + (e.pageX - start.x)
     const dy = e.pageY - start.y
     const dampen = dy > 0 ? 1.5 : 4
-    c.y = headerHeight + dy / dampen
+    y.value = headerHeight + dy / dampen
   }
 }
 
@@ -40,7 +42,7 @@ function stopDrag() {
   if (isDragging) {
     isDragging = false
     dynamics.animate(
-      c,
+      {x: x.value, y: y.value },
       { x: headerHeight, y: headerHeight },
       { type: dynamics.spring, duration: 700, firction: 280 }
     )

--- a/src/guide/typescript/composition-api.md
+++ b/src/guide/typescript/composition-api.md
@@ -100,24 +100,6 @@ const props = withDefaults(defineProps<Props>(), {
 
 Esto se compilará con las opciones de las props `default` equivalentes en tiempo de ejecución. Además, el helper `withDefaults` permite realizar comprobaciones de tipo para los valores por defecto, y asegura que el tipo `props` devuelto tiene las banderas opcionales removidas para las propiedades que sí tienen valores por defecto declarados.
 
-Alternativamente, puedes usar la versión actualmente experimental [Transformación de la Reactividad](/guide/extras/reactivity-transform.html):
-
-```vue
-<script setup lang="ts">
-interface Props {
-  name: string
-  count?: number
-}
-
-// desestructuración reactiva para defineProps()
-// el valor por defecto se compila a la opción
-// equivalente en tiempo de ejecución
-const { name, count = 100 } = defineProps<Props>()
-</script>
-```
-
-Este comportamiento requiere por el momento [opt-in explícito](/guide/extras/reactivity-transform.html#opt-in-explicito).
-
 ### Sin `<script setup>` {#without-script-setup}
 
 Si no usas `<script setup>`, es necesario utilizar `defineComponent()` para habilitar la inferencia del tipo de props. El tipo del objeto props pasado a `setup()` se infiere de la opción `props`.

--- a/src/partners/components/PartnerAll.vue
+++ b/src/partners/components/PartnerAll.vue
@@ -1,15 +1,16 @@
 <script setup lang="ts">
+import { ref } from 'vue'
 import PartnerHero from './PartnerHero.vue'
 import PartnerList from './PartnerList.vue'
 import PartnerJoin from './PartnerJoin.vue'
 import { Partner } from './type'
 import { VTIconSearch } from '@vue/theme'
 
-let query = $ref('')
+const query = ref('')
 
 function filter(p: Partner): boolean {
   return (
-    includes(p.name, query) || p.region.some((r) => includes(r, query))
+    includes(p.name, query.value) || p.region.some((r) => includes(r, query.value))
   )
 }
 

--- a/src/partners/components/PartnerCard.vue
+++ b/src/partners/components/PartnerCard.vue
@@ -3,7 +3,7 @@ import { Partner } from './type'
 import { normalizeName, getHero, getLogo, track } from './utils'
 import Location from './PartnerLocation.vue'
 
-const { data, hero, page } = defineProps<{
+const props = defineProps<{
   data: Partner
   hero?: boolean
   page?: boolean
@@ -18,7 +18,7 @@ const {
   proficiencies,
   flipLogo,
   website
-} = data
+} = props.data
 </script>
 
 <template>

--- a/src/partners/components/PartnerHero.vue
+++ b/src/partners/components/PartnerHero.vue
@@ -1,10 +1,10 @@
 <script setup lang="ts">
-const { title = 'Socios de Vue' } = defineProps<{ title?: string }>()
+defineProps<{ title?: string }>()
 </script>
 
 <template>
   <div class="PartnerHero">
-    <h1 class="title">{{ title }}</h1>
+    <h1 class="title">{{ title || 'Socios de Vue' }}</h1>
     <p class="lead">
       Los socios de Vue son agencias avaladas por el equipo de Vue que
       proveen servicios de consultoría y desarrollo de Vue de primera

--- a/src/partners/components/PartnerLanding.vue
+++ b/src/partners/components/PartnerLanding.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { onMounted } from 'vue'
+import { ref, onMounted } from 'vue'
 import PartnerHero from './PartnerHero.vue'
 import PartnerCard from './PartnerCard.vue'
 import PartnerList from './PartnerList.vue'
@@ -7,11 +7,11 @@ import PartnerJoin from './PartnerJoin.vue'
 import data from '../partners.json'
 import { Partner } from './type'
 
-let spotlighted = $ref<Partner | null>(null)
+const spotlighted = ref<Partner | null>(null)
 
 onMounted(() => {
   const plat = (data as Partner[]).filter((d) => d.platinum)
-  spotlighted = plat[Math.floor(Math.random() * plat.length)]
+  spotlighted.value = plat[Math.floor(Math.random() * plat.length)]
 })
 </script>
 

--- a/src/partners/components/PartnerList.vue
+++ b/src/partners/components/PartnerList.vue
@@ -1,28 +1,28 @@
 <script setup lang="ts">
 import partnersRaw from '../partners.json'
-import { computed, onMounted } from 'vue'
+import { ref, shallowRef, computed, onMounted } from 'vue'
 import PartnerCard from './PartnerCard.vue'
 import { Partner } from './type'
 
-const { filter, showLinkToAll } = defineProps<{
+const props = defineProps<{
   filter?: (p: Partner) => boolean | undefined
   showLinkToAll?: boolean
 }>()
 
-let mounted = $ref(false)
-let partners = $shallowRef(partnersRaw)
+const mounted = ref(false)
+const partners = shallowRef(partnersRaw as Partner[])
 
 const filtered = computed(() =>
-  filter ? (partners as Partner[]).filter(filter) : (partners as Partner[])
+  props.filter ? (partners.value as Partner[]).filter(props.filter) : (partners.value as Partner[])
 )
 
 onMounted(() => {
-  mounted = true
-  const platinum = partners.filter((p) => p.platinum)
+  mounted.value = true
+  const platinum = partners.value.filter((p) => p.platinum)
   shuffle(platinum)
-  const normal = partners.filter((p) => !p.platinum)
+  const normal = partners.value.filter((p) => !p.platinum)
   shuffle(normal)
-  partners = [...platinum, ...normal]
+  partners.value = [...platinum, ...normal]
 })
 
 function shuffle(array: Array<any>) {
@@ -50,7 +50,11 @@ function shuffle(array: Array<any>) {
     <ClientOnly>
       <PartnerCard v-for="p in filtered" :key="p.name" :data="p" />
     </ClientOnly>
-    <a class="browse-all" href="./all.html" v-if="showLinkToAll && filtered.length % 2">
+    <a 
+      class="browse-all"
+      href="./all.html"
+      v-if="showLinkToAll && filtered.length % 2"
+    >
       Explora y busca<br>Todos los socios
     </a>
   </div>
@@ -65,7 +69,7 @@ function shuffle(array: Array<any>) {
 
 .browse-all {
   color: var(--vt-c-text-2);
-  transition: color .5s ease;
+  transition: color 0.5s ease;
   font-size: 1.2em;
   text-align: center;
   padding-top: 240px;

--- a/src/partners/components/PartnerPage.vue
+++ b/src/partners/components/PartnerPage.vue
@@ -5,12 +5,12 @@ import { normalizeName, track } from './utils'
 import PartnerCard from './PartnerCard.vue'
 import { VTIconChevronLeft } from '@vue/theme'
 
-const { partner } = defineProps<{
+const props = defineProps<{
   partner: string
 }>()
 
 const p = (data as Partner[]).find(
-  (p) => normalizeName(p.name) === partner
+  (p) => normalizeName(p.name) === props.partner
 )!
 
 const { name, description, hiring, contact, website } = p


### PR DESCRIPTION
Addresses the commit: (https://github.com/vuejs/docs/commit/1bc0434c0d81f4cd45d96874d0b8982d6e8c9175) made by Evan, where reactivity transform is dropped from being used in the Vue docs.
