### PR TITLE
Página política de privacidad

### DIFF
--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -122,6 +122,7 @@ const nav: ThemeConfig['nav'] = [
         link: '/about/community-guide'
       },
       { text: 'Código de Conducta', link: '/about/coc' },
+      { text: 'Política de privacidad', link: '/about/privacy' },
       {
         text: 'El Documental',
         link: 'https://www.youtube.com/watch?v=OrxmtDw4pVI'
@@ -699,7 +700,7 @@ export default defineConfigWithTheme<ThemeConfig>({
         repo: 'https://github.com/vuejs-translations/docs-it'
       },
       {
-	link: 'https://ru.vuejs.org',
+        link: 'https://ru.vuejs.org',
         text: 'Русский',
         repo: 'https://github.com/translation-gang/docs-ru'
       },

--- a/src/about/privacy.md
+++ b/src/about/privacy.md
@@ -1,0 +1,42 @@
+# Política de Privacidad de Vue.js {#vue.js-privacy-policy}
+
+> Fecha de entrada en vigor: 3 de mayo de 2024
+
+Esta Política de Privacidad describe las prácticas de la organización Vue.js ("Vue", "nosotros", "nos" o "nuestro") con respecto al manejo de su información en relación con este sitio web ([https://vuejs.org](https://vuejs.org)) y nuestros sitios web relacionados con el código abierto ("Sitios web"), así como cualquier contenido, documentación relacionada, información y servicios (por ejemplo, tutoriales, herramientas para apoyar el flujo de trabajo del desarrollador, acceso a recursos, etc.) que se ponen a su disposición en este sitio web (colectivamente, los "Servicios"). Esta Política de Privacidad describe la información personal que procesamos para respaldar nuestros Servicios.
+
+Para mayor claridad, esta Política de Privacidad **no** se aplica a:
+
+1. El uso de código abierto, documentación o especificaciones disponibles en GitHub ([https://github.com/](https://github.com/)), los cuales están regidos por los términos de la licencia de código abierto correspondiente;
+
+2. Solicitudes de extracción (pull requests), incidencias (issues) y cualquier otra interacción o funcionalidad relacionada con la participación en proyectos de código abierto en GitHub, que se rigen por los términos y condiciones de GitHub; o
+
+3. Estadísticas de uso de nuestros paquetes publicados en NPM ([https://npmjs.com/](https://npmjs.com/)), que están regidas por los términos y condiciones de NPM; o
+
+4. Estadísticas de uso de nuestras extensiones de navegador / IDE publicadas, recopiladas por los proveedores de navegador / IDE. Tales estadísticas están regidas por los respectivos términos y condiciones de dichos proveedores.
+
+## ¿Qué tipo de información recopilamos? {#what-kinds-of-information-do-we-collect}
+
+**No** recopilamos ni almacenamos ningún tipo de dato personal, ya sea a través de nuestros sitios web, paquetes publicados en npm, o extensiones de navegador / IDE.
+
+Podemos recopilar datos anonimizados mediante servicios de terceros integrados en nuestros sitios web:
+
+* **Datos de visitantes a nuestros sitios web.** Nuestra analítica web es provista por [Fathom Analytics](https://usefathom.com/), que no utiliza cookies y cumple con el RGPD, ePrivacy (incluido PECR), COPPA y CCPA. Usando este software de análisis web respetuoso de la privacidad, su dirección IP solo se procesa brevemente, y nosotros (quienes administramos este sitio web) no tenemos forma de identificarle. Según la CCPA, su información personal está desidentificada. Puede leer más sobre esto en el sitio web de Fathom Analytics.
+
+  * Política de privacidad de Fathom Analytics: [https://usefathom.com/legal/privacy](https://usefathom.com/legal/privacy)
+
+* **Datos de uso de la funcionalidad de búsqueda.** Nuestra funcionalidad de búsqueda es proporcionada por [Algolia DocSearch](https://docsearch.algolia.com/), que no realiza ningún tipo de seguimiento del usuario ni utiliza técnicas de huella digital, y no utiliza cookies. Los servicios de Algolia son conformes con el RGPD, CCPA, y están certificados por TRUSTe.
+
+  * Política de privacidad de Algolia: [https://www.algolia.com/policies/privacy/](https://www.algolia.com/policies/privacy/)
+  * Cumplimiento de seguridad y privacidad de Algolia: [https://www.algolia.com/distributed-secure/security-compliance/](https://www.algolia.com/distributed-secure/security-compliance/)
+
+## ¿Cómo usamos la información? {#how-do-we-use-information}
+
+El único propósito de recopilar los datos mencionados anteriormente es entender el tráfico y uso de nuestro sitio web de la manera más respetuosa posible con la privacidad, para poder mejorar continuamente nuestro sitio web y la calidad de la documentación. La base legal según el RGPD es el "Artículo 6(1)(f); donde nuestros intereses legítimos son mejorar continuamente nuestro sitio web y negocio." Según lo explicado, no se almacenan datos personales a lo largo del tiempo.
+
+## Retención de datos {#data-retention}
+
+Todos los datos recopilados se almacenan en los servicios de terceros mencionados anteriormente y están sujetos a las políticas de retención de datos de dichos servicios.
+
+## Preguntas {#questions}
+
+Si tiene alguna pregunta sobre esta Política de Privacidad o nuestras prácticas, por favor contáctenos por correo electrónico a [hello@vuejs.org](mailto:hello@vuejs.org).


### PR DESCRIPTION
## Description of Problem
La documentación en español de Vue.js carecía de la página correspondiente a política de privacidad, lo cual podía generar confusión o una experiencia incompleta para los usuarios hispanohablantes. Al intentar acceder a dicha página, no existía ruta ni contenido disponible en la versión en español del sitio.

## Proposed Solution
Se agregó el archivo correspondiente con la traducción completa al español de la página política de privacidad.
Además, se actualizó la configuración de Vite (vitepress) para registrar correctamente la nueva ruta en la estructura de navegación y así hacer accesible esta nueva página desde la interfaz del sitio.

## Additional Information
