### PR TITLE
fixed: #85, #89 issues

### DIFF
--- a/src/guide/essentials/reactivity-fundamentals.md
+++ b/src/guide/essentials/reactivity-fundamentals.md
@@ -69,7 +69,7 @@ Cuando accedes a `this.someObject` después de asignarlo, el valor es un proxy r
 
 ## Declarando Estado Reactivo \*\* {#declaring-reactive-state-1}
 
-### `ref()` \*\* {#ref}
+### `ref()` \*\* {#ref}
 
 En la Composition API, la manera recomendada de declarar estado reactivo es usando la función [`ref()`](/api/reactivity-core#ref):
 
@@ -136,7 +136,7 @@ export default {
 
     function increment() {
       // .value es necesario en JavaScript
-      count.count++
+      count.value++
     }
 
     // no te olvides de exponer la función también.


### PR DESCRIPTION
## Description of Problem
issues:
- Typo in reactivity-fundamentals view #89
- Subtitle is not showing correctly #85
## Proposed Solution
De acuerdo a la documentacion en su version(ingles):
- Typo in reactivity-fundamentals view #89:
 tipo de caracter
- Subtitle is not showing correctly #85:
  count.value++
## Additional Information
