### PR TITLE
docs(es): Translate PreferenceTooltip content to Spanish

### DIFF
--- a/.vitepress/theme/components/PreferenceTooltip.vue
+++ b/.vitepress/theme/components/PreferenceTooltip.vue
@@ -92,30 +92,30 @@ function dismiss() {
   <Transition name="fly-in">
     <div class="preference-tooltip" v-if="show">
       <template v-if="source === 'default'">
-        <p>API style now defaults to Composition API.</p>
+        <p>El estilo de API ahora utiliza por defecto Composition API.</p>
         <p>
-          Some pages contain different content based on the API style
-          chosen. Use this switch to toggle between APIs styles.
+          Algunas páginas contienen contenido diferente basado en el estilo de API
+          elegido. Use este switch para cambiar entre estilos de APIs.
         </p>
       </template>
       <template v-if="source && source.startsWith('url')">
         <p>
-          Showing content for
-          {{ preferComposition ? 'Composition' : 'Options' }} API because
+          Mostrando contenido para
+          {{ preferComposition ? 'Composition' : 'Options' }} API porque
           {{
             source === 'url-query'
-              ? 'it is specified by the URL query.'
-              : 'the target section is only available for that API.'
+              ? 'está especificado por la consulta de URL.'
+              : 'la sección objetivo solo está disponible para esa API.'
           }}
         </p>
         <p>
-          This is different from your saved preference and will only affect
-          the current browsing session.
+          Esto es diferente de tu preferencia guardad y solo afectará
+          la sesión de navegación actual.
         </p>
       </template>
       <p class="actions">
-        <a href="/guide/introduction#api-styles">Learn more</a>
-        <button @click="dismiss">Got it</button>
+        <a href="/guide/introduction#api-styles">Aprender más</a>
+        <button @click="dismiss">Entendido</button>
       </p>
       <div class="arrow-top"></div>
       <div class="arrow-top inner"></div>


### PR DESCRIPTION
## Description of Problem
It was observed that the PreferenceTooltip component was still in English, so it was proposed to translate it to Spanish.

## Proposed Solution
The corresponding translations were made to the necessary labels.

## Additional Information
It's my first contribution to open source